### PR TITLE
Static rewrite method and using query_vars instead of $_GET for action.

### DIFF
--- a/VRPConnector.php
+++ b/VRPConnector.php
@@ -30,6 +30,6 @@ register_deactivation_hook( __FILE__, 'flush_rewrite_rules' );
  * Flush rewrite rules upon activation/deactivation.
  */
 function vrp_flush_rewrites() {
-	\Gueststream\VRPConnector::rewrite();
+	\Gueststream\VRPConnector::rewrite_activate();
 	flush_rewrite_rules();
 }

--- a/lib/VRPConnector.php
+++ b/lib/VRPConnector.php
@@ -18,7 +18,7 @@ class VRPConnector
     public $otheractions = array();                //
     public $time;                                  // Time (in seconds?) spent making calls to the API
     public $debug = array();                       // Container for debug data
-
+	public $action = false; // VRP Action 
     /**
      * Class Construct
      */
@@ -51,7 +51,7 @@ class VRPConnector
             return false;
         }
 
-        if (!isset($_GET['action'])) {
+        if (!$this->is_vrp_page()) {
             return false;
         }
 
@@ -78,27 +78,21 @@ class VRPConnector
         }
 
         // Actions
-        add_action("init", array($this, "ajax"));
-        add_action("init", array($this, "sitemap"));
-        add_action('init', array($this, "featuredunit"));
-        add_action("init", array($this, "otheractions"));
-        add_action('init', array($this, "rewrite"));
-        add_action('init', array($this, "villafilter"));
-        add_action('cacheClear', array($this, "clearCache"), 1, 3);
+        add_action('init', array($this, 'ajax'));
+        add_action('init', array($this, 'sitemap'));
+        add_action('init', array($this, 'featuredunit'));
+        add_action('init', array($this, 'otheractions'));
+        add_action('init', array($this, 'rewrite'));
+        add_action('init', array($this, 'villafilter'));
+        add_action('cacheClear', array($this, 'clearCache'), 1, 3);
         add_action('parse_request', array($this, 'router'));
 		add_action('update_option_vrpApiKey',array($this,'flush_rewrites'),10,2);
 		add_action('update_option_vrpAPI',array($this,'flush_rewrites'),10,2);
-		
-		
-        // Filters
-        add_filter('robots_txt', array($this, 'robots_mod'), 10, 2);
-        //add_filter('query_vars', array($this, 'query_vars'),10,1);
-        remove_filter('template_redirect', 'redirect_canonical');
+		add_action( 'wp', array( $this, 'remove_filters' ) );
 
-        if (isset($_GET['action'])) {
-            remove_filter('the_content', 'wptexturize');
-            remove_filter('the_content', 'wpautop');
-        }
+		// Filters
+        add_filter('robots_txt', array($this, 'robots_mod'), 10, 2);
+        remove_filter('template_redirect', 'redirect_canonical');
 
         // Shortcodes
 
@@ -170,6 +164,16 @@ class VRPConnector
 		
     }
 	
+	/**
+	 * Only on activation.
+	 */
+	static function rewrite_activate()
+	{
+		add_rewrite_tag('%action%', '([^&]+)');
+		add_rewrite_tag('%slug%', '([^&]+)');
+        add_rewrite_rule('^vrp/([^/]*)/([^/]*)/?', 'index.php?action=$matches[1]&slug=$matches[2]', 'top');
+		
+	}
 	function flush_rewrites($old,$new){
 		flush_rewrite_rules();
 	}
@@ -400,13 +404,15 @@ class VRPConnector
 
     public function villafilter()
     {
-        if (!isset($_GET['action'])) {
+        if (!$this->is_vrp_page()) {
             return;
         }
 
-        if ($_GET['action'] == 'complexsearch') {
+        if ('complexsearch' == $this->action) {
             if ($_GET['search']['type'] == 'Villa') {
-                $_GET['action'] = 'search';
+                $this->action = 'search';
+				global $wp_query;
+				$wp_query->query_vars['action']=$this->action;
             }
         }
     }
@@ -1335,5 +1341,27 @@ class VRPConnector
     {
        return; // Removing file cache
     }
-
+	/**
+	 * Checks to see if the page loaded is a VRP page.
+	 * Formally $_GET['action'].
+	 * @global WP_Query $wp_query
+	 * @return bool
+	 */
+	public function is_vrp_page()
+	{
+		global $wp_query;
+		if (isset($wp_query->query_vars['action'])){ // Is VRP page.
+			$this->action=$wp_query->query_vars['action'];
+			return true;
+		}
+		return false;
+	}
+	
+	public function remove_filters()
+	{
+		 if ( $this->is_vrp_page() ) {
+			remove_filter( 'the_content', 'wptexturize' );
+			remove_filter( 'the_content', 'wpautop' );
+		}
+	}
 }


### PR DESCRIPTION
Resolves error upon plugin activation when calling a non-static method. Replaced $_GET['action'] with query_vars. Resolves the issue with remove_filter not working (adding many <br> tags.