### PR TITLE
Force page template instead of index.php

### DIFF
--- a/lib/VRPConnector.php
+++ b/lib/VRPConnector.php
@@ -88,7 +88,8 @@ class VRPConnector
 		add_action('update_option_vrpApiKey',array($this,'flush_rewrites'),10,2);
 		add_action('update_option_vrpAPI',array($this,'flush_rewrites'),10,2);
 		add_action( 'wp', array( $this, 'remove_filters' ) );
-
+		add_action('pre_get_posts', array($this, 'query_template'));
+		
 		// Filters
         add_filter('robots_txt', array($this, 'robots_mod'), 10, 2);
         remove_filter('template_redirect', 'redirect_canonical');
@@ -132,7 +133,21 @@ class VRPConnector
             include $this->theme . "/functions.php";
         }
     }
-
+	/**
+	 * Alters WP_Query to tell it to load the page template instead of home.
+	 * @param WP_Query $query
+	 * @return WP_Query
+	 */
+	public function query_template($query)
+	{
+		if (!isset($query->query_vars['action'])) {
+            return $query;
+        }
+		$query->is_page=true;
+		$query->is_home=false;
+		return $query;
+	}
+	
     public function themeActions()
     {
         $theme = new $this->themename;


### PR DESCRIPTION
Since the update of the rewrite rules, VRP pages are loading on the index.php template. This will tell WP to load the page query instead.