### PR TITLE
Featured unit links fix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -48,7 +48,10 @@ you to seamlessly connect your website to your property management software data
 1. Out of the box unit page.
 
 == Changelog ==
-= 1.0.6 =
+= 1.0.8 =
+* Fixed unit permalink on Featured Unit shortcode templates.
+
+= 1.0.7 =
 * Automatically login to gueststream.net from settings page
 
 = 1.0.6 =

--- a/VRPConnector.php
+++ b/VRPConnector.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://www.gueststream.com/apps-and-tools/vrpconnector/
  * Description: Vacation Rental Platform Connector.
  * Author: Gueststream
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author URI: http://www.gueststream.com/
  */
 

--- a/themes/mountainsunset/vrpFeaturedUnit.php
+++ b/themes/mountainsunset/vrpFeaturedUnit.php
@@ -17,15 +17,17 @@
  * $data['Photo']
  * $data['Thumb']
  */
-if(is_array($data)) {
-    foreach($data as $unit) {
-        ?>
-        <a href="/vrp/unit/<?php echo $unit->page_slug; ?>"
-           Title="<?php echo $unit->Name; ?>"
-            >
+?>
+<?php if(is_array($data)) : ?>
+    <?php foreach($data as $unit) : ?>
+        <a href="<?php echo site_url("/vrp/unit/" . $unit->page_slug); ?>"
+           Title="<?php echo $unit->Name; ?>">
             <img src="<?php echo $unit->Photo; ?>">
         </a>
-    <?php
-    }
-}
-?>
+    <?php endforeach; ?>
+    <?php elseif (is_object($data)) : ?>
+    <a href="<?php echo site_url("/vrp/unit/" . $data->page_slug); ?>"
+       Title="<?php echo $data->Name; ?>">
+        <img src="<?php echo $data->Photo; ?>">
+    </a>
+<?php endif; ?>

--- a/themes/mountainsunset/vrpFeaturedUnits.php
+++ b/themes/mountainsunset/vrpFeaturedUnits.php
@@ -17,11 +17,11 @@
  * $data['Photo']
  * $data['Thumb']
  */
+?>
 
-foreach($data as $a_featured_unit) { ?>
-    <a href="/vrp/unit/<?php echo $a_featured_unit->page_slug; ?>"
-       Title="<?php echo $a_featured_unit->Name; ?>"
-        >
+<?php foreach($data as $a_featured_unit) : ?>
+    <a href="<?php echo site_url("/vrp/unit/" . $a_featured_unit->page_slug); ?>"
+       Title="<?php echo $a_featured_unit->Name; ?>">
         <img src="<?php echo $a_featured_unit->Photo; ?>">
     </a>
-<?php } ?>
+<?php endforeach; ?>


### PR DESCRIPTION
The featured unit template was not using wordpress site_url() for the unit page links.  This is now fixed.