### PR TITLE
Quote thumbnail url

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -50,6 +50,7 @@ you to seamlessly connect your website to your property management software data
 == Changelog ==
 = 1.0.8 =
 * Fixed unit permalink on Featured Unit shortcode templates.
+* Added single quotes to unit thumbnail photos in the result listing to allow URLs with spaces to function properly.
 
 = 1.0.7 =
 * Automatically login to gueststream.net from settings page

--- a/themes/mountainsunset/results.php
+++ b/themes/mountainsunset/results.php
@@ -66,7 +66,7 @@
 
                         </div>
                     </div>
-                    <div class="vrp-thumbnail text-center" style="background-image:url(<?php echo $unit->Thumb; ?>);">
+                    <div class="vrp-thumbnail text-center" style="background-image:url('<?php echo $unit->Thumb; ?>');">
                         <div class="vrp-actions">
                             <a href="#" data-unit="<?php echo $unit->id; ?>" class="vrp-favorite-button vrp-btn purple text-center">
                                 <i class="fa fa-fw fa-lg fa-heart"></i>


### PR DESCRIPTION
Placed single quotes around thumbnail photos on search results to allow urls with spaces in them to still work properly.