### PR TITLE
Removing travel insurance default form option

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -54,6 +54,7 @@ you to seamlessly connect your website to your property management software data
 * Making bathrooms search value session stored
 * Added calendar icons to arrival & departure input fields.
 * Storing user favorites in Cookies as well as php session to persist favorites for 30 days.
+* Travel Insurance option (if present) requires user to select yes or not rather than defaulting to one or the other.
 
 = 1.2.0 =
 * Added search result map with pins on the map for all results.

--- a/themes/mountainsunset/step3.php
+++ b/themes/mountainsunset/step3.php
@@ -138,8 +138,8 @@ global $vrp;
                 Travel insurance is available for your trip. ($<?php echo esc_html(number_format($data->InsuranceAmount, 2)); ?>) <br> Would
                 you like to purchase the optional travel insurance? <br>
                 <br>
-                <input type="radio" name="booking[acceptinsurance]" value="1" > Yes
-                <input type="radio" name="booking[acceptinsurance]" value="0" checked/> No
+                <input type="radio" name="booking[acceptinsurance]" value="1" required /> Yes
+                <input type="radio" name="booking[acceptinsurance]" value="0" /> No
                 <input type="hidden" name="booking[InsuranceAmount]"
                        value="<?php echo esc_attr($data->InsuranceAmount); ?>">
                 <?php if(isset($data->InsuranceID)) { ?>
@@ -167,14 +167,13 @@ global $vrp;
                 <tr id="ccTypetr">
                     <?php if (isset($data->booksettings->Cards)) { ?>
                         <td><b>Card Type*:</b></td>
-                        <td><select name="booking[ccType]">
-                                <?php
-                                foreach ($data->booksettings->Cards as $k => $v):
-                                    ?>
+                        <td>
+                            <select name="booking[ccType]">
+                                <?php foreach ($data->booksettings->Cards as $k => $v): ?>
                                     <option value="<?php echo esc_attr($k); ?>"><?php echo esc_attr($v); ?></option>
                                 <?php endforeach; ?>
-
-                            </select></td>
+                            </select>
+                        </td>
                     <?php } ?>
                 </tr>
                 <?php if (isset($data->booksettings->Cards)) { ?>


### PR DESCRIPTION
This sets no default for travel insurance (if present) so the guest is required to either opt in or opt out of travel insurance rather than having one or the other deafulted.