### PR TITLE
fixing unit page map initializer

### DIFF
--- a/themes/mountainsunset/js/vrp.unit.js
+++ b/themes/mountainsunset/js/vrp.unit.js
@@ -1,14 +1,14 @@
 /**
  * Unit Availability Check & Pricing Request/Breakdown
  */
-var disabledDays;
+var disabledDays, unitDataSource;
 
 jQuery(document).ready(function () {
 
     /**
      * JavaScript applied to the unit.php VRPConnector theme file
      */
-    var unitDataSource = jQuery("#unit-data");
+    unitDataSource = jQuery("#unit-data");
 
     /**
      * Determine if Unit Page Views module is enabled & log the page view if it is.
@@ -135,10 +135,6 @@ function ratebreakdown(obj) {
  * Google Map
  */
 
-jQuery("#gmaplink").on('click', function () {
-    initializeGoogleMap();
-});
-
 function initializeGoogleMap() {
     var geocoder = new google.maps.Geocoder();
     var map = new google.maps.Map(document.getElementById("map"), {
@@ -233,5 +229,9 @@ jQuery(document).ready(function () {
             }
         });
         return false;
+    });
+
+    jQuery("#gmaplink").on('click', function () {
+        initializeGoogleMap();
     });
 });


### PR DESCRIPTION
initializing the unit data variable in a scope the maps can access and moving the jquery selector identifying the gmaplink button wait for document ready before running.