### PR TITLE
set VRPConnector generated page as wp_query->queried_object

### DIFF
--- a/lib/DummyResult.php
+++ b/lib/DummyResult.php
@@ -5,6 +5,7 @@ namespace Gueststream;
 class DummyResult
 {
     public $ID;
+	public $ancestors = [];
     public $post_title;
     public $post_content;
     public $post_name;

--- a/lib/VRPConnector.php
+++ b/lib/VRPConnector.php
@@ -236,6 +236,8 @@ class VRPConnector
      */
     public function filterPosts($posts, $query)
     {
+	    global $wp_query;
+
         if (!isset($query->query_vars['action'])) {
             return $posts;
         }
@@ -260,7 +262,6 @@ class VRPConnector
                 $pagedescription = $data->SEODescription;
 
                 if (!isset($data->id)) {
-                    global $wp_query;
                     $wp_query->is_404 = true;
                 }
 
@@ -417,7 +418,12 @@ class VRPConnector
                 break;
         }
 
-        return [new DummyResult(0, $pagetitle, $content, $pagedescription)];
+	    $dummyResult = new DummyResult(0, $pagetitle, $content, $pagedescription);
+
+	    // Injecting our Post as the WP Queried Object
+	    $wp_query->queried_object = $dummyResult;
+
+	    return [$dummyResult];
     }
 
     private function specialPage($slug)


### PR DESCRIPTION
Set the called VRP page as wp_query->queried_object to better support SEO plugin functions.

I don't believe this is normal plugin process but the queried_object is never going to be set when a VRPConnector generated page is being loaded so we might as well set it.
