### PR TITLE
WP Admin Post search bugfix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: Houghtelin
 Tags: Vacation Rental Platform, Gueststream, VRP Connector, ISILink, HomeAway, Escapia, Barefoot, VRMGR
 Requires at least: 3.0.1
-Tested up to: 4.5.1
+Tested up to: 4.6
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.txt
+++ b/README.txt
@@ -52,6 +52,9 @@ you to seamlessly connect your website to your property management software data
 1. Out of the box unit page.
 
 == Changelog ==
+= 1.3.2 =
+* Fixed bug causing WP Admin Page & Post editor search to not show results.  Now, when searching for posts in WP Admin, all searched results will show.
+
 = 1.3.1 =
 * Updated search result template file to display errors if they are known.
 
@@ -161,6 +164,9 @@ you to seamlessly connect your website to your property management software data
 * Initial Release
 
 == Upgrade Notice ==
+= 1.3.2 =
+* WP Admin post search bug fix.
+
 = 1.3.0 =
 * New Search Widget feature added.
 

--- a/VRPConnector.php
+++ b/VRPConnector.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://www.gueststream.com/apps-and-tools/vrpconnector/
  * Description: Vacation Rental Platform Connector.
  * Author: Gueststream
- * Version: 1.3.1
+ * Version: 1.3.2
  * Author URI: http://www.gueststream.com/
  */
 

--- a/lib/VRPConnector.php
+++ b/lib/VRPConnector.php
@@ -236,7 +236,7 @@ class VRPConnector
      */
     public function filterPosts($posts, $query)
     {
-        if (!isset($query->query_vars['action'])) {
+	    if (!isset($query->query_vars['action']) || !isset($query->query_vars['slug'])) {
             return $posts;
         }
 


### PR DESCRIPTION
This fixes a bug that was causing the WP Admin post search function to fail by dumping all the posts via the filter posts method.