### PR TITLE
Allow use of VRPConnector in sub-directory WordPress installations

### DIFF
--- a/themes/desertsunrise/js/js.js
+++ b/themes/desertsunrise/js/js.js
@@ -145,23 +145,23 @@ if(jQuery( 'input[name="search[arrival]"]' ).length>0) {
 
     if (jQuery("#unitsincomplex").length > 0){
         if (jQuery("#hassession").length > 0){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).fadeIn();
             });
         }else{
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).fadeIn();
             });
         }
         jQuery("#jaxform").submit(function(){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).slideDown(1000);
             });
             return false;
         });
 
         jQuery("#showallofthem").click(function(){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).slideDown(1000);
             });
             return false;

--- a/themes/desertsunrise/js/vrp.unit - Copy.js
+++ b/themes/desertsunrise/js/vrp.unit - Copy.js
@@ -35,7 +35,7 @@ jQuery(document).ready(function () {
     }
 
     var unitSlug = unitDataSource.data('unit-slug');
-    jQuery.get("/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
         disabledDays = jQuery.parseJSON(data);
     });
 
@@ -96,7 +96,7 @@ function checkAvailability() {
     jQuery("#booklink").hide();
     jQuery("#loadingicons").show();
     jQuery("#ratebreakdown").empty();
-    jQuery.get("/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
         var obj = jQuery.parseJSON(data);
 
         if (!obj.Error) {
@@ -264,7 +264,7 @@ jQuery(document).ready(function () {
 
     jQuery("#vrpinquire").submit(function () {
         jQuery("#iqbtn").attr("disabled", "disabled");
-        jQuery.post("/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
+        jQuery.post(url_paths.site_url + "/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
             var obj = jQuery.parseJSON(data);
             if (obj.success) {
                 jQuery("#vrpinquire").replaceWith("Thank you for your inquiry!");

--- a/themes/desertsunrise/js/vrp.unit.js
+++ b/themes/desertsunrise/js/vrp.unit.js
@@ -35,7 +35,7 @@ jQuery(document).ready(function () {
     }
 
     var unitSlug = unitDataSource.data('unit-slug');
-    jQuery.get("/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
         disabledDays = jQuery.parseJSON(data);
     });
 
@@ -107,7 +107,7 @@ function checkAvailability() {
     jQuery("#booklink").hide();
     jQuery("#loadingicons").show();
     jQuery("#ratebreakdown").empty();
-    jQuery.get("/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
         var obj = jQuery.parseJSON(data);
 
         if (!obj.Error) {
@@ -244,7 +244,7 @@ jQuery(document).ready(function () {
 
     jQuery("#vrpinquire").submit(function () {
         jQuery("#iqbtn").attr("disabled", "disabled");
-        jQuery.post("/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
+        jQuery.post(url_paths.site_url + "/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
             var obj = jQuery.parseJSON(data);
             if (obj.success) {
                 jQuery("#vrpinquire").replaceWith("Thank you for your inquiry!");

--- a/themes/mountainsunset/js/js.js
+++ b/themes/mountainsunset/js/js.js
@@ -111,23 +111,23 @@ jQuery(document).ready(function(){
 
     if (jQuery("#unitsincomplex").length > 0){
         if (jQuery("#hassession").length > 0){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).fadeIn();
             });
         }else{
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).fadeIn();
             });
         }
         jQuery("#jaxform").submit(function(){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).slideDown(1000);
             });
             return false;
         });
 
         jQuery("#showallofthem").click(function(){
-            jQuery.get("/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
+            jQuery.get(url_paths.site_url + "/?vrpjax=1&act=searchjax",jQuery("#jaxform2").serialize(),function(data){
                 jQuery("#unitsincomplex").hide().html(data).slideDown(1000);
             });
             return false;

--- a/themes/mountainsunset/js/vrp.unit.js
+++ b/themes/mountainsunset/js/vrp.unit.js
@@ -25,7 +25,7 @@ jQuery(document).ready(function () {
     });
 
     var unitSlug = unitDataSource.data('unit-slug');
-    jQuery.get("/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=getUnitBookedDates&par=" + unitSlug, function (data) {
         disabledDays = jQuery.parseJSON(data);
     });
 
@@ -84,7 +84,7 @@ function checkAvailability() {
     jQuery("#booklink").hide();
     jQuery("#loadingicons").show();
     jQuery("#ratebreakdown").empty();
-    jQuery.get("/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
+    jQuery.get(url_paths.site_url + "/?vrpjax=1&act=checkavailability&par=1", jQuery("#bookingform").serialize(), function (data) {
         var obj = jQuery.parseJSON(data);
 
         if (!obj.Error) {
@@ -211,7 +211,7 @@ jQuery(document).ready(function () {
 
     jQuery("#vrpinquire").submit(function () {
         jQuery("#iqbtn").attr("disabled", "disabled");
-        jQuery.post("/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
+        jQuery.post(url_paths.site_url + "/?vrpjax=1&act=custompost&par=addinquiry", jQuery(this).serialize(), function (data) {
             var obj = jQuery.parseJSON(data);
             if (obj.success) {
                 jQuery("#vrpinquire").replaceWith("Thank you for your inquiry!");


### PR DESCRIPTION
Certain XHR calls were targeting the root of the domain, and are now using url_paths.site_url to target the WordPress installation root